### PR TITLE
Fix: Header 및 ConditionalFooter body태그 내로 이동

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,9 +15,11 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko">
-      <Header />
-      <body>{children}</body>
-      <ConditionalFooter />
+      <body>
+        <Header />
+        {children}
+        <ConditionalFooter />
+      </body>
     </html>
   )
 }


### PR DESCRIPTION
## #️⃣ PR 일자

> 20250624

## 📝 PR 내용

> `Header`와 `ConditionalFooter` 컴포넌트가 body 태그 외부로 빠져있었음(제잘못 ..) -> 이거 수정

## ✅ 체크리스트

- [x] 코드가 잘 작동하고 있나요?
- [x] 기능 단위로 커밋을 나눴나요?

## 📎 관련 이슈

>  Closes #6 

### 스크린샷 (선택)
