### PR TITLE
Feat: 각 구장 맛집 구장 개수 API 연결(백엔드 수정ver)

### DIFF
--- a/components/Main/MainStadiumsList/StadiumCard.tsx
+++ b/components/Main/MainStadiumsList/StadiumCard.tsx
@@ -57,7 +57,9 @@ function MainStadiumCard({ stadium }: MainStadiumCardProps) {
         <div className={subTitle()}>{stadium.address}</div>
       </div>
       <div className={flexRowICenter('justify-between')}>
-        <span className={subTitle()}>맛집 N곳</span>
+        <span className={subTitle()}>
+          맛집 {stadium.restaurantCount}곳
+        </span>
         <button
           className={button('rounded-2xl', 'p-2', 'text-sm')}
           onClick={handleClick}

--- a/types/Stadium.ts
+++ b/types/Stadium.ts
@@ -6,9 +6,10 @@ export interface Stadium {
   latitude: number
   longitude: number
   logo: string
+  restaurantCount: number
 }
 
-export interface StadiumInfo{
+export interface StadiumInfo {
   id?: number
   name: string
   team?: string
@@ -19,7 +20,7 @@ export interface StadiumInfo{
   restaurants: RestaurantInfo[] | []
 }
 
-export interface RestaurantInfo{
+export interface RestaurantInfo {
   id: number
   name: string
   category?: string
@@ -34,6 +35,6 @@ export interface RestaurantInfo{
   avgRating?: number
 }
 
-export interface RestaurantCardInfo{
+export interface RestaurantCardInfo {
   restaurant: RestaurantInfo
 }


### PR DESCRIPTION
## #️⃣ PR 일자

> 20250627

## 📝 PR 내용

> 메인페이지에서 각 구장에 연결된 맛집 개수 N개로 표시하던거 백엔드 수정 후 API 연결

## ✅ 체크리스트

- [x] 코드가 잘 작동하고 있나요?
- [x] 기능 단위로 커밋을 나눴나요?

## 📎 관련 이슈

> Closes #11 

### 스크린샷 (선택)
<img width="1006" alt="image" src="https://github.com/user-attachments/assets/428eecf6-f243-49b6-bd3d-9aaf9017dfcc" />
