### PR TITLE
Fix: 모바일 메인 지도 타이틀 줄넘김으로 인해 타이틀명 변경

### DIFF
--- a/components/Main/MainStadiumsMap/index.tsx
+++ b/components/Main/MainStadiumsMap/index.tsx
@@ -64,7 +64,7 @@ function MainStadiumMap({ keyword }: MainStadiumsMapProps) {
     <div className={flexCol(Card('w-full'))}>
       <Tabs>
         <div className={flexRowICenter('justify-between')}>
-          <div className={cardTitle()}>전국 K리그 구장</div>
+          <div className={cardTitle()}>구장 지도</div>
           <StadiumTabs onSelect={setLeague} />
         </div>
         <div


### PR DESCRIPTION
## #️⃣ PR 일자

> 20250628

## 📝 PR 내용

> 메인페이지 Map API 부분 타이틀 변경

## ✅ 체크리스트

- [x] 코드가 잘 작동하고 있나요?
- [x] 기능 단위로 커밋을 나눴나요?

## 📎 관련 이슈

> Closes #12 

### 스크린샷 (선택)
<img width="1572" alt="image" src="https://github.com/user-attachments/assets/30cecc8b-3ccb-4545-bbe4-ddd25c89caeb" />
