### PR TITLE
Feat: 마이페이지 즐겨찾기 삭제 개선

### DIFF
--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -42,6 +42,16 @@ export default function Page() {
     fetchUser()
   }, [accessToken])
 
+  const removeFavorite = (restaurantId: number) => {
+    if (!user) return
+    setUser({
+      ...user,
+      favorites: user.favorites.filter(
+        (fav) => fav.restaurant.id !== restaurantId,
+      ),
+    })
+  }
+
   if (!hasMounted || !accessToken) return <LoadingSpinner />
   if (!user) return <LoadingSpinner />
 
@@ -77,6 +87,7 @@ export default function Page() {
           <MypageTabs
             favorites={user.favorites}
             reviews={user.reviews}
+            onRemoveFavorite={removeFavorite}
           />
         </div>
       </div>

--- a/components/Card/FavoriteButton.tsx
+++ b/components/Card/FavoriteButton.tsx
@@ -15,11 +15,13 @@ import { cn } from '@/lib/utils'
 interface FavoriteButtonProps {
   restaurantId: number
   version?: 'icon' | 'pill'
+  onRemoveFavorite?: (restaurantId: number) => void
 }
 
 export default function FavoriteButton({
   restaurantId,
   version = 'icon',
+  onRemoveFavorite,
 }: FavoriteButtonProps) {
   const [isFavorite, setIsFavorite] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
@@ -65,6 +67,7 @@ export default function FavoriteButton({
       if (isFavorite) {
         await deleteFavorite(restaurantId)
         setIsFavorite(false)
+        onRemoveFavorite?.(restaurantId)
       } else {
         await addFavorite(restaurantId)
         setIsFavorite(true)

--- a/components/Card/RestaurantCard.tsx
+++ b/components/Card/RestaurantCard.tsx
@@ -19,6 +19,7 @@ export default function RestaurantCard({
   restaurant,
   showDistance,
   stadiumName,
+  onRemoveFavorite,
 }: RestaurantCardInfo) {
   const router = useRouter()
   const handleDetailClick = () => {
@@ -35,6 +36,7 @@ export default function RestaurantCard({
           <FavoriteButton
             restaurantId={restaurant.id}
             version="icon"
+            onRemoveFavorite={onRemoveFavorite}
           />
         </div>
       </div>

--- a/components/MyPage/UserHistory/MypageTabs.tsx
+++ b/components/MyPage/UserHistory/MypageTabs.tsx
@@ -11,11 +11,13 @@ import UserReviews from './UserReviews'
 interface UserTabsProps {
   favorites: FavoriteProps[]
   reviews: ReviewProps[]
+  onRemoveFavorite?: (restaurantId: number) => void
 }
 
 export default function MypageTabs({
   favorites,
   reviews,
+  onRemoveFavorite,
 }: UserTabsProps) {
   return (
     <Tabs
@@ -28,7 +30,10 @@ export default function MypageTabs({
       </TabsList>
 
       <TabsContent value="favorites">
-        <UserFavorites favorites={favorites} />
+        <UserFavorites
+          favorites={favorites}
+          onRemoveFavorite={onRemoveFavorite}
+        />
       </TabsContent>
 
       <TabsContent value="reviews">

--- a/components/MyPage/UserHistory/UserFavorites.tsx
+++ b/components/MyPage/UserHistory/UserFavorites.tsx
@@ -5,10 +5,12 @@ import { getStadiumNameById } from '@/utils/getStudiumById'
 
 interface UserFavoritesProps {
   favorites: FavoriteProps[]
+  onRemoveFavorite?: (restaurantId: number) => void
 }
 
 export default function UserFavorites({
   favorites,
+  onRemoveFavorite,
 }: UserFavoritesProps) {
   if (favorites.length === 0)
     return <div>즐겨찾기한 식당이 없습니다.</div>
@@ -32,6 +34,7 @@ export default function UserFavorites({
             restaurant={{ ...restaurant }}
             showDistance={false}
             stadiumName={getStadiumNameById(restaurant.stadiumId)}
+            onRemoveFavorite={onRemoveFavorite}
           />
         ))}
       </div>

--- a/types/Restaurant.ts
+++ b/types/Restaurant.ts
@@ -24,6 +24,7 @@ export interface RestaurantCardInfo {
   restaurant: Restaurant
   showDistance?: boolean
   stadiumName?: string
+  onRemoveFavorite?: (restaurantId: number) => void
 }
 
 export type RestaurantSortType = '평점순' | '리뷰순' | '이름순'


### PR DESCRIPTION
## #️⃣ PR 일자
20250709

## 📝 PR 내용
- 마이페이지 즐겨찾기 바로 삭제되도록 변환: 추후 리팩토링 때 zustand로 props drilling 개선 필요

## ✅ 체크리스트

- [ ] 코드가 잘 작동하고 있나요?
- [ ] 기능 단위로 커밋을 나눴나요?

## 📎 관련 이슈
Closes #52 