### PR TITLE
Feature#88: 메인페이지 인기맛집 수정

### DIFF
--- a/components/Main/MainRestaurantsList/RestaurantTabsContent.tsx
+++ b/components/Main/MainRestaurantsList/RestaurantTabsContent.tsx
@@ -4,8 +4,8 @@ import { Restaurant } from '@/types/Restaurant'
 import { Swiper, SwiperSlide } from 'swiper/react'
 import MainRestaurantCard from './RestaurantCard'
 import 'swiper/css'
-import 'swiper/css/navigation'
-import { Navigation } from 'swiper/modules'
+import 'swiper/css/pagination'
+import { Pagination } from 'swiper/modules'
 import SwiperCardSkeleton from '@/components/Skeleton/SwiperCardSkeleton'
 
 type RestaurantTabsContentProps = {
@@ -38,8 +38,8 @@ function RestaurantTabsContent({
           value={value}
         >
           <Swiper
-            modules={[Navigation]}
-            navigation={true}
+            modules={[Pagination]}
+            pagination={true}
             spaceBetween={24}
             grabCursor={true}
             breakpoints={{

--- a/components/Main/SectionTabsHeader.tsx
+++ b/components/Main/SectionTabsHeader.tsx
@@ -11,7 +11,9 @@ function SectionTabsHeader({
 }: SectionTabsHeaderProps) {
   return (
     <div className={flexRowICenter('justify-between')}>
-      <div className={cardTitle()}>{title}</div>
+      <div className={cardTitle('w-[6rem]', ' whitespace-nowrap')}>
+        {title}
+      </div>
       {children}
     </div>
   )


### PR DESCRIPTION
## #️⃣ PR 일자

> 20250722

## 📝 PR 내용

> 인기 맛집 Swiper -> Pagination 수정
> 인기 맛집 타이틀 줄넘김으로 인해 rem + white-space nowrap 적용

## ✅ 체크리스트

- [x] 코드가 잘 작동하고 있나요?
- [x] 기능 단위로 커밋을 나눴나요?

## 📎 관련 이슈

> Closed #88 
